### PR TITLE
Fixes bug where example sketch only reads one time

### DIFF
--- a/firmware/examples/Adafruit_L3GD20_test.ino
+++ b/firmware/examples/Adafruit_L3GD20_test.ino
@@ -58,6 +58,6 @@ void loop()
     "x: " + String(gyro.data.x) +
     " y: " + String(gyro.data.y) +
     " z: " + String(gyro.data.z),PRIVATE);
-    }
     old_time = millis();
+    }
 }


### PR DESCRIPTION
Minor bugfix. Previously the example sketch would only read data once, as the last_time variable needs to be updated inside the if-block. Otherwise the last_time is always immediately before the if-check, so it never triggers again.